### PR TITLE
Fixing timezone issue for zones west of UTC (Fixes #7)

### DIFF
--- a/components/xml.js
+++ b/components/xml.js
@@ -80,7 +80,7 @@ function getUFCDate(date) {
 		];
 	const year = date.toString().match(/[0-9]{4}/)[0];
 	const time = date.toString().match(/[0-9]{2}:[0-9]{2}:[0-9]{2}/)[0];
-	const timezone = date.toString().match(/\+[0-9]{4}/)[0];
+	const timezone = date.toString().match(/[+-][0-9]{4}/)[0];
 	return `${weekDay}, ${day} ${month} ${year} ${time} ${timezone}`;
 }
 


### PR DESCRIPTION
Found the issue and figured this is one of the only ways I can pay you back for the theme. Hope you find the contributions helpful, 

The fix is just slightly adjusting that regex, time zones should only be + or - with 4 digits so I think this should cover it.